### PR TITLE
Resolving script engine memory issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ val testDep = Seq(
   "org.scalactic" %% "scalactic" % scalacticVersion % "test,it",
   "org.scalatest" %% "scalatest" % scalacticVersion % "test,it",
   "com.github.tomakehurst" % "wiremock-jre8" % wiremockVersion % Test,
-  "org.scalamock" %% "scalamock" % scalamockVersion % Test,
+  "org.scalamock" %% "scalamock" % scalamockVersion % "test,it",
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,

--- a/src/it/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumerIntSpec.scala
+++ b/src/it/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumerIntSpec.scala
@@ -3,8 +3,10 @@ package it.ldsoftware.starling.engine.consumers
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.DatabaseUtils
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.{Consumed, ProcessContext}
 import org.apache.commons.lang3.RandomStringUtils
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -19,14 +21,15 @@ class DatabaseConsumerIntSpec
     with Matchers
     with Eventually
     with ScalaFutures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with MockFactory {
 
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(15, Millis)))
 
   import slick.jdbc.H2Profile.api._
 
-  private val pc = ProcessContext(ActorSystem("test"))
+  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"
   private val db = DatabaseUtils.getDatabase(jdbcUrl, "org.h2.Driver")
 

--- a/src/it/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractorIntSpec.scala
+++ b/src/it/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractorIntSpec.scala
@@ -3,8 +3,10 @@ package it.ldsoftware.starling.engine.extractors
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.DatabaseUtils
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
 import org.apache.commons.lang3.RandomStringUtils
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -13,11 +15,16 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 //noinspection SqlDialectInspection,SqlNoDataSourceInspection
-class DatabaseExtractorIntSpec extends AnyWordSpec with Matchers with ScalaFutures with IntegrationPatience {
+class DatabaseExtractorIntSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with MockFactory {
 
   import slick.jdbc.H2Profile.api._
 
-  private val pc = ProcessContext(ActorSystem("test"))
+  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"
   private val db = DatabaseUtils.getDatabase(jdbcUrl, "org.h2.Driver")
 

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -5,7 +5,7 @@ it.ldsoftware.starling {
   par-level = 4
   par-level = ${?MAX_THREADS}
 
-  max-script-engines = 4
+  max-script-engines = ${it.ldsoftware.starling.par-level}
   max-script-engines = ${?MAX_SCRIPT_ENGINES}
 
   server {

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -2,6 +2,12 @@ it.ldsoftware.starling {
   mode = "standalone"
   mode = ${?STARLING_MODE}
 
+  par-level = 4
+  par-level = ${?MAX_THREADS}
+
+  max-script-engines = 4
+  max-script-engines = ${?MAX_SCRIPT_ENGINES}
+
   server {
     port: 8080
     port = ${?HTTP_PORT}

--- a/src/main/scala/it/ldsoftware/starling/StarlingApp.scala
+++ b/src/main/scala/it/ldsoftware/starling/StarlingApp.scala
@@ -17,7 +17,7 @@ object StarlingApp extends App with LazyLogging {
   def run(config: AppConfig, args: Array[String]): Unit =
     config.getMode match {
       case AppConfig.ServerMode     => processServer(config)
-      case AppConfig.StandaloneMode => processStandalone(args)
+      case AppConfig.StandaloneMode => processStandalone(config, args)
       case _                        => throw new Error("STARLING_MODE env var not found!")
     }
 
@@ -25,11 +25,11 @@ object StarlingApp extends App with LazyLogging {
     ActorSystem[Nothing](ServerBehavior(config), "starling-studio")
   }
 
-  private def processStandalone(args: Array[String]): Unit = {
+  private def processStandalone(config: AppConfig, args: Array[String]): Unit = {
     logger.info("Starting in standalone mode")
     Option(args.head).map(new File(_)) match {
       case None       => logger.error("No descriptor provided, quitting.")
-      case Some(file) => new ProcessRunner().startProcessFromFile(file)
+      case Some(file) => new ProcessRunner().startProcessFromFile(file, config)
     }
   }
 

--- a/src/main/scala/it/ldsoftware/starling/configuration/AppConfig.scala
+++ b/src/main/scala/it/ldsoftware/starling/configuration/AppConfig.scala
@@ -12,6 +12,9 @@ case class AppConfig(private val config: Config) {
   lazy val dbUser: String = config.getString("it.ldsoftware.starling.server.database.user")
   lazy val dbPass: String = config.getString("it.ldsoftware.starling.server.database.pass")
 
+  lazy val parallelism: Int = config.getInt("it.ldsoftware.starling.par-level")
+  lazy val maxScriptEngines: Int = config.getInt("it.ldsoftware.starling.max-script-engines")
+
 }
 
 object AppConfig {

--- a/src/main/scala/it/ldsoftware/starling/engine/ProcessContext.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/ProcessContext.scala
@@ -3,6 +3,7 @@ package it.ldsoftware.starling.engine
 import akka.actor.ActorSystem
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.stream.Materializer
+import it.ldsoftware.starling.configuration.AppConfig
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
@@ -15,7 +16,7 @@ import scala.concurrent.ExecutionContext
   *
   * @param system the main actor system that is used to run the process
   */
-case class ProcessContext(system: ActorSystem, tokenCaches: mutable.Map[String, TokenProvider] = mutable.Map()) {
+case class ProcessContext(system: ActorSystem, appConfig: AppConfig, tokenCaches: mutable.Map[String, TokenProvider] = mutable.Map()) {
 
   lazy val materializer: Materializer = Materializer(system)
 

--- a/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{RunnableGraph, Sink}
 import com.typesafe.scalalogging.LazyLogging
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.extensions.IOExtensions.FileFromFileExtensions
 
 import java.io.{File, PrintWriter}
@@ -18,13 +19,13 @@ class ProcessRunner extends LazyLogging {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
   implicit val mat: Materializer = Materializer(system)
 
-  def startProcessFromFile(file: File): Unit =
+  def startProcessFromFile(file: File, appConfig: AppConfig): Unit =
     if (!file.exists()) {
       logger.error(s"Specified file ${file.getAbsolutePath} does not exist")
     } else {
       val manifest = file.readFile
       logger.debug(s"Executing following plan:\n$manifest")
-      val pc = ProcessContext(system)
+      val pc = ProcessContext(system, appConfig)
 
       val process = new ProcessFactory(4).generateProcess(manifest, pc)
 

--- a/src/main/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractor.scala
@@ -33,6 +33,9 @@ class DatabaseExtractor(
   override def toPipedExtractor(data: Extracted): Extractor =
     new DatabaseExtractor(query, ds, config, data)
 
+  override def summary: String =
+    s"Database extractor trying to execute $query interpolated with $initialValue"
+
 }
 
 object DatabaseExtractor extends ExtractorBuilder {

--- a/src/main/scala/it/ldsoftware/starling/engine/extractors/FailFastExtractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/extractors/FailFastExtractor.scala
@@ -20,4 +20,5 @@ class FailFastExtractor(message: String, override val config: Config, override v
   override def toPipedExtractor(data: Extracted): Extractor =
     new FailFastExtractor(message, config)
 
+  override def summary: String = "Will never be used"
 }

--- a/src/main/scala/it/ldsoftware/starling/engine/extractors/HttpExtractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/extractors/HttpExtractor.scala
@@ -41,6 +41,7 @@ class HttpExtractor(
   override def toPipedExtractor(data: Extracted): Extractor =
     new HttpExtractor(url <-- data, subPath, auth, http, config, data)
 
+  override def summary: String = "HttpExtractor failed TODO"
 }
 
 object HttpExtractor extends ExtractorBuilder {

--- a/src/main/scala/it/ldsoftware/starling/extensions/ScriptEngineExtensions.scala
+++ b/src/main/scala/it/ldsoftware/starling/extensions/ScriptEngineExtensions.scala
@@ -1,0 +1,52 @@
+package it.ldsoftware.starling.extensions
+
+import it.ldsoftware.starling.configuration.AppConfig
+
+import javax.script.{ScriptContext, ScriptEngine, ScriptEngineManager}
+import scala.annotation.tailrec
+import scala.concurrent.{ExecutionContext, Future}
+
+object ScriptEngineExtensions {
+
+  class ScriptEnginePool(language: String, appConfig: AppConfig)(implicit ec: ExecutionContext) {
+
+    private val pool = (0 until appConfig.maxScriptEngines).map { _ =>
+      new ScriptEngineWrapper(new ScriptEngineManager().getEngineByName(language))
+    }
+
+    def getFreeEngine: Future[ScriptEngineWrapper] =
+      Future {
+        pool.synchronized {
+          @tailrec def findFirstFree: ScriptEngineWrapper = {
+            val opt = pool.find(_.free)
+            if (opt.isEmpty) findFirstFree else opt.get
+          }
+
+          val engineWrapper = findFirstFree
+          engineWrapper.lock()
+          engineWrapper
+        }
+      }
+
+  }
+
+  class ScriptEngineWrapper(engine: ScriptEngine) {
+
+    var free: Boolean = true
+
+    def lock(): Unit = {
+      free = false
+    }
+
+    def execute[T](function: ScriptEngine => T): T = {
+      try {
+        function(engine)
+      } finally {
+        engine.setBindings(engine.createBindings(), ScriptContext.GLOBAL_SCOPE)
+        free = true
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/it/ldsoftware/starling/engine/consumers/ConsumerFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/consumers/ConsumerFactorySpec.scala
@@ -2,11 +2,13 @@ package it.ldsoftware.starling.engine.consumers
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class ConsumerFactorySpec extends AnyWordSpec with Matchers {
+class ConsumerFactorySpec extends AnyWordSpec with Matchers with MockFactory {
 
   // language=JSON
   private val config =
@@ -19,7 +21,7 @@ class ConsumerFactorySpec extends AnyWordSpec with Matchers {
 
     "build the correct consumer from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val consumers = ConsumerFactory.getConsumers(c, pc)
 
       consumers should have size 1

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/DummyExtractor.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/DummyExtractor.scala
@@ -13,6 +13,8 @@ class DummyExtractor(val parameter: String, override val config: Config, overrid
     Future.successful(Seq(Right(Map("extracted" -> parameter))))
 
   override def toPipedExtractor(data: Extracted): Extractor = new DummyExtractor(parameter, config, data)
+
+  override def summary: String = "Dummy extractor failed"
 }
 
 object DummyExtractor extends ExtractorBuilder {

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorFactorySpec.scala
@@ -2,11 +2,13 @@ package it.ldsoftware.starling.engine.extractors
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class ExtractorFactorySpec extends AnyWordSpec with Matchers {
+class ExtractorFactorySpec extends AnyWordSpec with Matchers with MockFactory {
 
   // language=JSON
   private val config =
@@ -19,7 +21,7 @@ class ExtractorFactorySpec extends AnyWordSpec with Matchers {
 
     "build the correct extractor from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractors = ExtractorFactory.getExtractors(c, pc)
 
       extractors should have size 1

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorSpec.scala
@@ -2,12 +2,14 @@ package it.ldsoftware.starling.engine.extractors
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures with IntegrationPatience {
+class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures with IntegrationPatience with MockFactory {
 
   "an extractor" should {
     "emit new data when the configuration does not specify anything" in {
@@ -25,7 +27,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("extracted" -> "template string")))
@@ -46,7 +48,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("extracted" -> "template string")))
@@ -67,7 +69,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       val expected = Map("old" -> "value", "extracted" -> "template string")

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/HttpExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/HttpExtractorSpec.scala
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.client.{BasicCredentials, WireMock}
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.{ProcessContext, TokenProvider}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.GivenWhenThen
@@ -29,7 +30,7 @@ class HttpExtractorSpec
   WireMock.configureFor(wireMock.port())
 
   private val system = ActorSystem("test-http-extractor")
-  private val pc = ProcessContext(system)
+  private val pc = ProcessContext(system, mock[AppConfig])
 
   "extract" should {
     "get the whole response as extraction result" in {

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractorSpec.scala
@@ -1,7 +1,7 @@
 package it.ldsoftware.starling.engine.extractors
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
 import org.scalamock.scalatest.MockFactory
@@ -34,8 +34,13 @@ class ScalaEvalExtractorSpec
           |  ]
           |}""".stripMargin
 
+      val mockConfig = mock[Config]
+      val appConfig = AppConfig(mockConfig)
+
+      (mockConfig.getInt _).expects("it.ldsoftware.starling.max-script-engines").returning(4)
+
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), appConfig)
       val extractor = ExtractorFactory.getExtractors(c, pc).head
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))
@@ -58,8 +63,13 @@ class ScalaEvalExtractorSpec
 
       val initialData = Map("element" -> "value")
 
+      val mockConfig = mock[Config]
+      val appConfig = AppConfig(mockConfig)
+
+      (mockConfig.getInt _).expects("it.ldsoftware.starling.max-script-engines").returning(4)
+
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), appConfig)
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(initialData)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))
@@ -82,8 +92,13 @@ class ScalaEvalExtractorSpec
 
       val initialData = Map("element" -> "value")
 
+      val mockConfig = mock[Config]
+      val appConfig = AppConfig(mockConfig)
+
+      (mockConfig.getInt _).expects("it.ldsoftware.starling.max-script-engines").returning(4)
+
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), appConfig)
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(initialData)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractorSpec.scala
@@ -2,6 +2,7 @@ package it.ldsoftware.starling.engine.extractors
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.GivenWhenThen
@@ -34,7 +35,7 @@ class ScalaEvalExtractorSpec
           |}""".stripMargin
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))
@@ -58,7 +59,7 @@ class ScalaEvalExtractorSpec
       val initialData = Map("element" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(initialData)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))
@@ -82,7 +83,7 @@ class ScalaEvalExtractorSpec
       val initialData = Map("element" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(initialData)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("element" -> "value")))

--- a/src/test/scala/it/ldsoftware/starling/engine/providers/OAuth2TokenProviderSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/providers/OAuth2TokenProviderSpec.scala
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
 import org.apache.commons.lang3.RandomStringUtils
 import org.scalamock.scalatest.MockFactory
@@ -31,7 +32,7 @@ class OAuth2TokenProviderSpec
   WireMock.configureFor(wireMock.port())
 
   private val system = ActorSystem("test-oauth2-provider")
-  private val pc = ProcessContext(system)
+  private val pc = ProcessContext(system, mock[AppConfig])
 
   override def beforeEach(): Unit = {
     wireMock.resetAll()

--- a/src/test/scala/it/ldsoftware/starling/engine/providers/TokenProviderFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/providers/TokenProviderFactorySpec.scala
@@ -2,12 +2,14 @@ package it.ldsoftware.starling.engine.providers
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import it.ldsoftware.starling.configuration.AppConfig
 import it.ldsoftware.starling.engine.ProcessContext
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TokenProviderFactorySpec extends AnyWordSpec with Matchers with ScalaFutures {
+class TokenProviderFactorySpec extends AnyWordSpec with Matchers with ScalaFutures with MockFactory {
 
   // language=JSON
   private val config =
@@ -20,7 +22,7 @@ class TokenProviderFactorySpec extends AnyWordSpec with Matchers with ScalaFutur
 
     "build the correct token provider from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"))
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
       val providers = TokenProviderFactory.getTokenProviders(c, pc)
 
       providers should have size 1


### PR DESCRIPTION
When using the script extractor, creating a new script engine for each extractor was too memory consuming. With this, we limit the maximum number of script engines for each process, in order to save memory.

Also improving the debugging capabilities by adding a summary to each extractor that will be relayed in case of failures