### PR TITLE
Adding throttling options to extractors and consumers

### DIFF
--- a/src/it/resources/standalone-mode.conf
+++ b/src/it/resources/standalone-mode.conf
@@ -6,4 +6,5 @@ akka {
 
 it.ldsoftware.starling {
   mode = "standalone"
+  par-level = 4
 }

--- a/src/main/scala/it/ldsoftware/starling/engine/Consumer.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/Consumer.scala
@@ -1,7 +1,10 @@
 package it.ldsoftware.starling.engine
 
 import com.typesafe.config.Config
+import it.ldsoftware.starling.extensions.ConfigExtensions.ConfigOperations
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -11,6 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait Consumer {
 
   implicit val ec: ExecutionContext
+  val config: Config
 
   /**
     * Consumes the outcome of the extraction process. This function is called whenever
@@ -42,6 +46,11 @@ trait Consumer {
           case exc => NotConsumed(this.getClass.getSimpleName, exc.getMessage, Some(value), Some(exc))
         }
     }
+
+  final lazy val throttling =
+    config
+      .getOptDuration("throttle")
+      .map(d => FiniteDuration(d.toNanos, TimeUnit.NANOSECONDS))
 
 }
 

--- a/src/main/scala/it/ldsoftware/starling/engine/Extractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/Extractor.scala
@@ -4,6 +4,8 @@ import com.typesafe.config.Config
 import it.ldsoftware.starling.engine.extractors.FailFastExtractor
 import it.ldsoftware.starling.extensions.ConfigExtensions.ConfigOperations
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -72,6 +74,11 @@ trait Extractor {
       case Left(value)  => new FailFastExtractor(value, config)
       case Right(value) => toPipedExtractor(value)
     }
+
+  final lazy val throttling =
+    config
+      .getOptDuration("throttle")
+      .map(d => FiniteDuration(d.toNanos, TimeUnit.NANOSECONDS))
 
 }
 

--- a/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
@@ -27,7 +27,7 @@ class ProcessRunner extends LazyLogging {
       logger.debug(s"Executing following plan:\n$manifest")
       val pc = ProcessContext(system, appConfig)
 
-      val process = new ProcessFactory(4).generateProcess(manifest, pc)
+      val process = new ProcessFactory(appConfig.parallelism).generateProcess(manifest, pc)
 
       val loggerSink = Sink.fold[String, ConsumerResult]("") {
         case (acc, Consumed(info)) =>

--- a/src/main/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumer.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumer.scala
@@ -9,7 +9,8 @@ import it.ldsoftware.starling.extensions.UsableExtensions.{LetOperations, Usable
 import javax.sql.DataSource
 import scala.concurrent.{ExecutionContext, Future}
 
-class DatabaseConsumer(query: String, ds: DataSource)(implicit val ec: ExecutionContext) extends Consumer {
+class DatabaseConsumer(query: String, ds: DataSource, override val config: Config)(implicit val ec: ExecutionContext)
+    extends Consumer {
 
   override def consumeSuccess(data: Extracted): Future[ConsumerResult] =
     Future {
@@ -28,7 +29,7 @@ object DatabaseConsumer extends ConsumerBuilder {
     val query = config.getString("query")
     val conn = DatabaseExtensions.getDataSource(config)
     implicit val executionContext: ExecutionContext = pc.executionContext
-    new DatabaseConsumer(query, conn)
+    new DatabaseConsumer(query, conn, config)
   }
 
 }

--- a/src/main/scala/it/ldsoftware/starling/engine/consumers/PrinterConsumer.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/consumers/PrinterConsumer.scala
@@ -8,7 +8,9 @@ import it.ldsoftware.starling.extensions.UsableExtensions.LetOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class PrinterConsumer(template: String)(implicit val ec: ExecutionContext) extends Consumer with LazyLogging {
+class PrinterConsumer(template: String, override val config: Config)(implicit val ec: ExecutionContext)
+    extends Consumer
+    with LazyLogging {
 
   override def consumeSuccess(data: Extracted): Future[ConsumerResult] =
     Future {
@@ -23,6 +25,6 @@ class PrinterConsumer(template: String)(implicit val ec: ExecutionContext) exten
 object PrinterConsumer extends ConsumerBuilder {
 
   override def apply(config: Config, pc: ProcessContext): Consumer =
-    new PrinterConsumer(config.getString("template"))(pc.executionContext)
+    new PrinterConsumer(config.getString("template"), config)(pc.executionContext)
 
 }

--- a/src/main/scala/it/ldsoftware/starling/engine/extractors/FailFastExtractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/extractors/FailFastExtractor.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param message message indicating the reason of the failure
   */
-class FailFastExtractor(message: String, override val config: Config, override val initialValue: Extracted = Map())(
+final class FailFastExtractor(message: String, override val config: Config, override val initialValue: Extracted = Map())(
     implicit val ec: ExecutionContext
 ) extends Extractor {
 

--- a/src/main/scala/it/ldsoftware/starling/extensions/ConfigExtensions.scala
+++ b/src/main/scala/it/ldsoftware/starling/extensions/ConfigExtensions.scala
@@ -2,14 +2,23 @@ package it.ldsoftware.starling.extensions
 
 import com.typesafe.config.Config
 
+import java.time.Duration
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 object ConfigExtensions {
   implicit class ConfigOperations(config: Config) {
+
     def getConfigSList(path: String): List[Config] =
       if (config.hasPath(path)) config.getConfigList(path).asScala.toList
       else Nil
-    def getStringOrNull(path: String): String = if (config.hasPath(path)) config.getString(path) else null
-    def getOptString(path: String): Option[String] = Option(getStringOrNull(path))
+
+    def getStringOrNull(path: String): String =
+      if (config.hasPath(path)) config.getString(path) else null
+
+    def getOptString(path: String): Option[String] =
+      Option(getStringOrNull(path))
+
+    def getOptDuration(path: String): Option[Duration] =
+      if (config.hasPath(path)) Some(config.getDuration(path)) else None
   }
 }

--- a/src/test/scala/it/ldsoftware/starling/engine/consumers/DummyConsumer.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/consumers/DummyConsumer.scala
@@ -5,12 +5,13 @@ import it.ldsoftware.starling.engine._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DummyConsumer(val parameter: String)(implicit val ec: ExecutionContext) extends Consumer {
+class DummyConsumer(val parameter: String, override val config: Config)(implicit val ec: ExecutionContext)
+    extends Consumer {
   override def consumeSuccess(data: Extracted): Future[ConsumerResult] =
     Future.successful(Consumed("DummyConsumer"))
 }
 
 object DummyConsumer extends ConsumerBuilder {
   override def apply(config: Config, pc: ProcessContext): Consumer =
-    new DummyConsumer(config.getString("parameter"))(pc.executionContext)
+    new DummyConsumer(config.getString("parameter"), config)(pc.executionContext)
 }


### PR DESCRIPTION
Sometimes, when working with rate-limited API or just to avoid sudden workload bursts, it could be useful to slow down the execution of a process.

An optional throttling configuration is added to both extractors and consumers, and can be used to only evaluate one element for each configured time window.