### PR TITLE
Adding file resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val wiremockVersion = "2.32.0"
 val scalamockVersion = "5.2.0"
 val postgresqlVersion = "42.3.3"
 val flywayVersion = "8.5.4"
-val projectScalaVersion = "2.13.8"
+val projectScalaVersion = "2.13.6"
 
 val akka = Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,

--- a/src/it/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumerIntSpec.scala
+++ b/src/it/scala/it/ldsoftware/starling/engine/consumers/DatabaseConsumerIntSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.DatabaseUtils
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.{Consumed, ProcessContext}
+import it.ldsoftware.starling.engine.{Consumed, FileResolver, ProcessContext}
 import org.apache.commons.lang3.RandomStringUtils
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
@@ -29,7 +29,7 @@ class DatabaseConsumerIntSpec
 
   import slick.jdbc.H2Profile.api._
 
-  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"
   private val db = DatabaseUtils.getDatabase(jdbcUrl, "org.h2.Driver")
 

--- a/src/it/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractorIntSpec.scala
+++ b/src/it/scala/it/ldsoftware/starling/engine/extractors/DatabaseExtractorIntSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.DatabaseUtils
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.apache.commons.lang3.RandomStringUtils
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -24,7 +24,7 @@ class DatabaseExtractorIntSpec
 
   import slick.jdbc.H2Profile.api._
 
-  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+  private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"
   private val db = DatabaseUtils.getDatabase(jdbcUrl, "org.h2.Driver")
 

--- a/src/main/scala/it/ldsoftware/starling/engine/FileResolver.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/FileResolver.scala
@@ -1,0 +1,7 @@
+package it.ldsoftware.starling.engine
+
+trait FileResolver {
+
+  def retrieveFile(fileName: String): String
+
+}

--- a/src/main/scala/it/ldsoftware/starling/engine/ProcessContext.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/ProcessContext.scala
@@ -16,7 +16,12 @@ import scala.concurrent.ExecutionContext
   *
   * @param system the main actor system that is used to run the process
   */
-case class ProcessContext(system: ActorSystem, appConfig: AppConfig, tokenCaches: mutable.Map[String, TokenProvider] = mutable.Map()) {
+case class ProcessContext(
+    system: ActorSystem,
+    appConfig: AppConfig,
+    fileResolver: FileResolver,
+    tokenCaches: mutable.Map[String, TokenProvider] = mutable.Map()
+) {
 
   lazy val materializer: Materializer = Materializer(system)
 
@@ -27,5 +32,7 @@ case class ProcessContext(system: ActorSystem, appConfig: AppConfig, tokenCaches
   def getTokenCache(name: String): TokenProvider = tokenCaches(name)
 
   def addTokenCache(name: String, tokenProvider: TokenProvider): Unit = tokenCaches.put(name, tokenProvider)
+
+  def retrieveFile(name: String): String = fileResolver.retrieveFile(name)
 
 }

--- a/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/ProcessRunner.scala
@@ -5,6 +5,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{RunnableGraph, Sink}
 import com.typesafe.scalalogging.LazyLogging
 import it.ldsoftware.starling.configuration.AppConfig
+import it.ldsoftware.starling.engine.resolvers.LocalFileResolver
 import it.ldsoftware.starling.extensions.IOExtensions.FileFromFileExtensions
 
 import java.io.{File, PrintWriter}
@@ -25,7 +26,7 @@ class ProcessRunner extends LazyLogging {
     } else {
       val manifest = file.readFile
       logger.debug(s"Executing following plan:\n$manifest")
-      val pc = ProcessContext(system, appConfig)
+      val pc = ProcessContext(system, appConfig, new LocalFileResolver(file))
 
       val process = new ProcessFactory(appConfig.parallelism).generateProcess(manifest, pc)
 

--- a/src/main/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractor.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/extractors/ScalaEvalExtractor.scala
@@ -3,7 +3,6 @@ package it.ldsoftware.starling.engine.extractors
 import com.typesafe.config.Config
 import it.ldsoftware.starling.engine._
 import it.ldsoftware.starling.engine.extractors.ScalaEvalExtractor.CallToFunction
-import it.ldsoftware.starling.extensions.IOExtensions.FileFromStringExtensions
 import it.ldsoftware.starling.extensions.ScriptEngineExtensions.ScriptEnginePool
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -50,7 +49,7 @@ object ScalaEvalExtractor extends ExtractorBuilder {
   override def apply(config: Config, pc: ProcessContext): Extractor = {
     val script = config.getString("type") match {
       case "inline" => String.format(WrapperFunction, config.getString("script"))
-      case "file"   => config.getString("file").readFile
+      case "file"   => pc.retrieveFile(config.getString("file"))
       case x        => throw new Error(s"Cannot handle script of type $x")
     }
     implicit val ec: ExecutionContext = pc.executionContext

--- a/src/main/scala/it/ldsoftware/starling/engine/resolvers/LocalFileResolver.scala
+++ b/src/main/scala/it/ldsoftware/starling/engine/resolvers/LocalFileResolver.scala
@@ -1,0 +1,17 @@
+package it.ldsoftware.starling.engine.resolvers
+
+import it.ldsoftware.starling.engine.FileResolver
+import it.ldsoftware.starling.extensions.IOExtensions.FileFromStringExtensions
+
+import java.io.File
+import scala.annotation.tailrec
+
+class LocalFileResolver(processFile: File) extends FileResolver {
+
+  private val relativeRoot = processFile.getAbsolutePath.substring(0, processFile.getAbsolutePath.lastIndexOf("/"))
+
+  @tailrec final override def retrieveFile(fileName: String): String =
+    if (fileName.startsWith("/")) fileName.readFile
+    else retrieveFile(s"$relativeRoot/$fileName")
+
+}

--- a/src/main/scala/it/ldsoftware/starling/extensions/CredentialManager.scala
+++ b/src/main/scala/it/ldsoftware/starling/extensions/CredentialManager.scala
@@ -3,9 +3,6 @@ package it.ldsoftware.starling.extensions
 import com.typesafe.config.{Config, ConfigFactory}
 import it.ldsoftware.starling.extensions.ConfigExtensions.ConfigOperations
 import it.ldsoftware.starling.extensions.IOExtensions.FileFromStringExtensions
-import it.ldsoftware.starling.extensions.UsableExtensions.UsableCloseable
-
-import scala.io.Source
 
 object CredentialManager {
 

--- a/src/main/scala/it/ldsoftware/starling/extensions/Interpolator.scala
+++ b/src/main/scala/it/ldsoftware/starling/extensions/Interpolator.scala
@@ -3,7 +3,6 @@ package it.ldsoftware.starling.extensions
 import freemarker.template.{Configuration, Template, Version}
 import it.ldsoftware.starling.engine.Extracted
 import it.ldsoftware.starling.extensions.UsableExtensions.MutateOperations
-import slick.jdbc.{PositionedParameters, SQLActionBuilder}
 
 import java.io.{StringReader, StringWriter}
 import java.sql.{Connection, PreparedStatement}
@@ -60,18 +59,6 @@ object Interpolator {
             case (ps, next) => ps.mutate(_.setObject(next._2, params(next._1)))
           }
       }
-  }
-
-  implicit class SlickInterpolator(a: SQLActionBuilder) {
-    def +(b: SQLActionBuilder): SQLActionBuilder = {
-      SQLActionBuilder(
-        a.queryParts ++ b.queryParts,
-        (p: Unit, pp: PositionedParameters) => {
-          a.unitPConv.apply(p, pp)
-          b.unitPConv.apply(p, pp)
-        }
-      )
-    }
   }
 
 }

--- a/src/test/resources/absolute-file.txt
+++ b/src/test/resources/absolute-file.txt
@@ -1,0 +1,1 @@
+absolute

--- a/src/test/resources/relative-dir/reference-file.txt
+++ b/src/test/resources/relative-dir/reference-file.txt
@@ -1,0 +1,1 @@
+reference

--- a/src/test/resources/relative-dir/relative-file.txt
+++ b/src/test/resources/relative-dir/relative-file.txt
@@ -1,0 +1,1 @@
+relative

--- a/src/test/resources/testScript.scala
+++ b/src/test/resources/testScript.scala
@@ -1,1 +1,0 @@
-def produce(data: Map[String, Any]): Map[String, Any] = Map("element" -> data("element"))

--- a/src/test/scala/it/ldsoftware/starling/engine/consumers/ConsumerFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/consumers/ConsumerFactorySpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.starling.engine.consumers
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -21,7 +21,7 @@ class ConsumerFactorySpec extends AnyWordSpec with Matchers with MockFactory {
 
     "build the correct consumer from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val consumers = ConsumerFactory.getConsumers(c, pc)
 
       consumers should have size 1

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorFactorySpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.starling.engine.extractors
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -21,7 +21,7 @@ class ExtractorFactorySpec extends AnyWordSpec with Matchers with MockFactory {
 
     "build the correct extractor from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val extractors = ExtractorFactory.getExtractors(c, pc)
 
       extractors should have size 1

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/ExtractorSpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.starling.engine.extractors
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should
@@ -27,7 +27,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("extracted" -> "template string")))
@@ -48,7 +48,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       extractor.extract().futureValue shouldBe Seq(Right(Map("extracted" -> "template string")))
@@ -69,7 +69,7 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val data = Map("old" -> "value")
 
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       val expected = Map("old" -> "value", "extracted" -> "template string")

--- a/src/test/scala/it/ldsoftware/starling/engine/extractors/HttpExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/extractors/HttpExtractorSpec.scala
@@ -7,7 +7,7 @@ import com.github.tomakehurst.wiremock.client.{BasicCredentials, WireMock}
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.{ProcessContext, TokenProvider}
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext, TokenProvider}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.GivenWhenThen
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -30,7 +30,7 @@ class HttpExtractorSpec
   WireMock.configureFor(wireMock.port())
 
   private val system = ActorSystem("test-http-extractor")
-  private val pc = ProcessContext(system, mock[AppConfig])
+  private val pc = ProcessContext(system, mock[AppConfig], mock[FileResolver])
 
   "extract" should {
     "get the whole response as extraction result" in {

--- a/src/test/scala/it/ldsoftware/starling/engine/providers/OAuth2TokenProviderSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/providers/OAuth2TokenProviderSpec.scala
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.apache.commons.lang3.RandomStringUtils
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterEach, GivenWhenThen}
@@ -32,7 +32,7 @@ class OAuth2TokenProviderSpec
   WireMock.configureFor(wireMock.port())
 
   private val system = ActorSystem("test-oauth2-provider")
-  private val pc = ProcessContext(system, mock[AppConfig])
+  private val pc = ProcessContext(system, mock[AppConfig], mock[FileResolver])
 
   override def beforeEach(): Unit = {
     wireMock.resetAll()

--- a/src/test/scala/it/ldsoftware/starling/engine/providers/TokenProviderFactorySpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/providers/TokenProviderFactorySpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.starling.engine.providers
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.starling.configuration.AppConfig
-import it.ldsoftware.starling.engine.ProcessContext
+import it.ldsoftware.starling.engine.{FileResolver, ProcessContext}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -22,7 +22,7 @@ class TokenProviderFactorySpec extends AnyWordSpec with Matchers with ScalaFutur
 
     "build the correct token provider from a configuration" in {
       val c = ConfigFactory.parseString(config)
-      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig])
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
       val providers = TokenProviderFactory.getTokenProviders(c, pc)
 
       providers should have size 1

--- a/src/test/scala/it/ldsoftware/starling/engine/resolvers/LocalFileResolverSpec.scala
+++ b/src/test/scala/it/ldsoftware/starling/engine/resolvers/LocalFileResolverSpec.scala
@@ -1,0 +1,27 @@
+package it.ldsoftware.starling.engine.resolvers
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.GivenWhenThen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
+
+class LocalFileResolverSpec extends AnyWordSpec with GivenWhenThen with Matchers with MockFactory {
+
+  "the local file resolver" should {
+    "read file from a relative path" in {
+      val rootReference = new File("./src/test/resources/relative-dir/reference-file.txt")
+      val target = "relative-file.txt"
+      new LocalFileResolver(rootReference).retrieveFile(target) shouldBe "relative"
+    }
+
+    "read file from an absolute path" in {
+      val absoluteFile = new File("./src/test/resources/absolute-file.txt").getAbsolutePath
+      val rootReference = new File("./src/test/resources/relative-dir/reference-file.txt")
+      new LocalFileResolver(rootReference).retrieveFile(absoluteFile) shouldBe "absolute"
+    }
+  }
+
+
+}


### PR DESCRIPTION
In order to simplify the process of pipeline creation, now it is possible to specify relative file paths in the extractors.

For example, if the ScalaExtractor required the following:

```json
{
  "type": "ScalaEvalExtractor",
  "config": {
    "type": "file",
    "file": "/full/path/to/file.scala"
  }
}
```

but the file was in the same directory as the process json, now we can write:

```json
{
  "type": "ScalaEvalExtractor",
  "config": {
    "type": "file",
    "file": "file.scala"
  }
}
```

Of course, full paths from the root directory are still supported