### PR TITLE
Adding an HTTP consumer, bringing out common configurations

### DIFF
--- a/src/main/scala/it/ldsoftware/migra/engine/AuthMethod.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/AuthMethod.scala
@@ -1,0 +1,40 @@
+package it.ldsoftware.migra.engine
+
+import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
+import com.typesafe.config.Config
+import it.ldsoftware.migra.extensions.CredentialManager
+
+import scala.concurrent.{ExecutionContext, Future}
+
+sealed trait AuthMethod {
+  def toHeaders(implicit ec: ExecutionContext): Future[Seq[HttpHeader]] =
+    this match {
+      case NoAuth                => Future.successful(Seq())
+      case BasicAuth(user, pass) => Future.successful(Seq(Authorization(BasicHttpCredentials(user, pass))))
+      case BearerAuth(bearer)    => Future.successful(Seq(Authorization(OAuth2BearerToken(bearer))))
+      case OAuth2Auth(cache)     => cache.token.map(t => Seq(Authorization(OAuth2BearerToken(t))))
+    }
+}
+
+case object NoAuth extends AuthMethod
+case class BasicAuth(user: String, pass: String) extends AuthMethod
+case class BearerAuth(bearer: String) extends AuthMethod
+case class OAuth2Auth(tokenCache: TokenProvider) extends AuthMethod
+
+object AuthMethod {
+
+  def fromConfig(config: Config, pc: ProcessContext): AuthMethod = {
+    if (config.hasPath("auth")) {
+      val authConfig = config.getConfig("auth")
+      authConfig.getString("type") match {
+        case "basic"  => BasicAuth.tupled(CredentialManager.getCredentials(authConfig))
+        case "bearer" => BearerAuth(CredentialManager.getToken(authConfig))
+        case "oauth2" => OAuth2Auth(pc.getTokenCache(authConfig.getString("provider")))
+      }
+    } else {
+      NoAuth
+    }
+  }
+
+}

--- a/src/main/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumer.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumer.scala
@@ -1,0 +1,70 @@
+package it.ldsoftware.migra.engine.consumers
+
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.model.{HttpEntity, HttpMethod, HttpMethods, HttpRequest, MediaTypes}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
+import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.extensions.ConfigExtensions.ConfigOperations
+import it.ldsoftware.migra.extensions.Interpolator._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  *
+  */
+class HttpJsonConsumer(
+    url: String,
+    jsonTemplate: String,
+    method: HttpMethod,
+    auth: AuthMethod,
+    http: HttpExt,
+    val config: Config
+)(implicit
+    val ec: ExecutionContext,
+    mat: Materializer
+) extends Consumer
+    with LazyLogging {
+
+  override def consumeSuccess(data: Extracted): Future[ConsumerResult] =
+    Future(jsonTemplate <-- data)
+      .flatMap(json => sendRequest(json, data))
+      .recover(exc => NotConsumed(getClass.getName, "An exception occurred", Some(data), Some(exc)))
+
+  private def sendRequest(json: String, data: Extracted): Future[ConsumerResult] =
+    Future(json)
+      .map(json => HttpEntity(MediaTypes.`application/json`, json))
+      .zip(auth.toHeaders)
+      .map {
+        case (entity, headers) =>
+          HttpRequest(method, url <-- data, headers, entity)
+      }
+      .flatMap(r => http.singleRequest(r))
+      .flatMap(r => Unmarshal(r).to[String].map(s => (r.status, s)))
+      .map {
+        case (respCode, _) if respCode.isSuccess() =>
+          Consumed(s"${method.value} ${url <-- data} with $json executed with success")
+        case (code, body) if code.isFailure() =>
+          NotConsumed(getClass.getName, s"Calling $url with $json returned $code: $body", Some(data), None)
+      }
+}
+
+object HttpJsonConsumer extends ConsumerBuilder {
+
+  override def apply(config: Config, pc: ProcessContext): Consumer = {
+    val url = config.getString("url")
+    val auth = AuthMethod.fromConfig(config, pc)
+    val template = config.getString("template")
+    val method = config.getOptString("method") match {
+      case Some(name) => HttpMethods.getForKeyCaseInsensitive(name).getOrElse(HttpMethods.POST)
+      case None       => HttpMethods.POST
+    }
+    implicit val executionContext: ExecutionContext = pc.executionContext
+    implicit val materializer: Materializer = pc.materializer
+
+    new HttpJsonConsumer(url, template, method, auth, pc.http, config)
+  }
+
+}

--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/HttpExtractor.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/HttpExtractor.scala
@@ -1,16 +1,13 @@
 package it.ldsoftware.migra.engine.extractors
 
 import akka.http.scaladsl.HttpExt
-import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import it.ldsoftware.migra.engine._
-import it.ldsoftware.migra.engine.extractors.HttpExtractor.AuthMethod
-import it.ldsoftware.migra.extensions.Interpolator.StringInterpolator
 import it.ldsoftware.migra.extensions.ConfigExtensions.ConfigOperations
-import it.ldsoftware.migra.extensions.CredentialManager
+import it.ldsoftware.migra.extensions.Interpolator.StringInterpolator
 import it.ldsoftware.migra.extensions.JacksonExtension._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,57 +28,34 @@ class HttpExtractor(
     auth.toHeaders
       .map(headers => HttpRequest(uri = url, headers = headers))
       .flatMap(r => http.singleRequest(r))
-      .flatMap(r => Unmarshal(r).to[String])
-      .map(json => json.jsonGet(subPath))
+      .flatMap(r => Unmarshal(r).to[String].map(s => (r.status, s)))
       .map {
-        case SubArray(seq)   => seq.map(Right(_))
-        case SubGeneric(gen) => Seq(Right(gen))
+        case (status, json) if status.intValue() < 300 => produceSuccess(json.jsonGet(subPath))
+        case (_, error)                                => Seq(Left(error))
       }
 
   override def toPipedExtractor(data: Extracted): Extractor =
     new HttpExtractor(url <-- data, subPath, auth, http, config, data)
 
   override def summary: String = "HttpExtractor failed TODO"
+
+  private def produceSuccess(property: SubProperty): Seq[ExtractionResult] =
+    property match {
+      case SubArray(seq)   => seq.map(e => Right(e))
+      case SubGeneric(gen) => Seq(Right(gen))
+    }
 }
 
 object HttpExtractor extends ExtractorBuilder {
 
-  sealed trait AuthMethod {
-    def toHeaders(implicit ec: ExecutionContext): Future[Seq[HttpHeader]] =
-      this match {
-        case NoAuth                => Future.successful(Seq())
-        case BasicAuth(user, pass) => Future.successful(Seq(Authorization(BasicHttpCredentials(user, pass))))
-        case BearerAuth(bearer)    => Future.successful(Seq(Authorization(OAuth2BearerToken(bearer))))
-        case OAuth2Auth(cache)     => cache.token.map(t => Seq(Authorization(OAuth2BearerToken(t))))
-      }
-  }
-
-  case object NoAuth extends AuthMethod
-  case class BasicAuth(user: String, pass: String) extends AuthMethod
-  case class BearerAuth(bearer: String) extends AuthMethod
-  case class OAuth2Auth(tokenCache: TokenProvider) extends AuthMethod
-
   override def apply(config: Config, pc: ProcessContext): Extractor = {
     val url = config.getString("url")
     val subPath = config.getOptString("subPath")
-    val auth = extractAuth(config, pc)
+    val auth = AuthMethod.fromConfig(config, pc)
     implicit val executionContext: ExecutionContext = pc.executionContext
     implicit val materializer: Materializer = pc.materializer
 
     new HttpExtractor(url, subPath, auth, pc.http, config, Map())
-  }
-
-  private def extractAuth(config: Config, pc: ProcessContext): AuthMethod = {
-    if (config.hasPath("auth")) {
-      val authConfig = config.getConfig("auth")
-      authConfig.getString("type") match {
-        case "basic"  => BasicAuth.tupled(CredentialManager.getCredentials(authConfig))
-        case "bearer" => BearerAuth(CredentialManager.getToken(authConfig))
-        case "oauth2" => OAuth2Auth(pc.getTokenCache(authConfig.getString("provider")))
-      }
-    } else {
-      NoAuth
-    }
   }
 
 }

--- a/src/main/scala/it/ldsoftware/migra/extensions/CredentialManager.scala
+++ b/src/main/scala/it/ldsoftware/migra/extensions/CredentialManager.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import it.ldsoftware.migra.extensions.ConfigExtensions.ConfigOperations
 import it.ldsoftware.migra.extensions.IOExtensions.FileFromStringExtensions
 
-object CredentialManager {
+object CredentialManager { // TODO put in PC so that we can get file configuration from relative pos
 
   def getCredentials(config: Config): (String, String) =
     if (!config.hasPath("credentials")) {

--- a/src/test/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumerSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumerSpec.scala
@@ -1,0 +1,131 @@
+package it.ldsoftware.migra.engine.consumers
+
+import akka.actor.ActorSystem
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.typesafe.config.ConfigFactory
+import it.ldsoftware.migra.configuration.AppConfig
+import it.ldsoftware.migra.engine.{Consumed, FileResolver, ProcessContext}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.GivenWhenThen
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HttpJsonConsumerSpec
+    extends AnyWordSpec
+    with GivenWhenThen
+    with Matchers
+    with MockFactory
+    with ScalaFutures
+    with IntegrationPatience {
+
+  private val wireMock = new WireMockServer(wireMockConfig().dynamicPort())
+  wireMock.start()
+  WireMock.configureFor(wireMock.port())
+
+  private val system = ActorSystem("test-http-consumer")
+  private val pc = ProcessContext(system, mock[AppConfig], mock[FileResolver])
+
+  "consumeSuccess" should {
+    "send a POST request with the compiled json" in {
+
+      val url = s"http://localhost:${wireMock.port()}"
+      val template = """{\"param1\": \"${string}\", \"param2\": ${number}}"""
+
+      //language=JSON
+      val config =
+        s"""
+          |{
+          |  "url": "$url",
+          |  "template": "$template"
+          |}
+          |""".stripMargin
+
+      val data = Map("string" -> "string", "number" -> 1)
+
+      stubFor(post("/").willReturn(aResponse().withStatus(201)))
+
+      val subject = HttpJsonConsumer(ConfigFactory.parseString(config), pc)
+
+      val expectedJson = """{"param1": "string", "param2": 1}"""
+
+      subject.consumeSuccess(data).futureValue shouldBe Consumed(s"POST $url with $expectedJson executed with success")
+
+      verify(
+        postRequestedFor(urlEqualTo("/"))
+          .withHeader("Content-Type", equalTo("application/json"))
+          .withRequestBody(matchingJsonPath("$.param1", equalTo("string")))
+          .withRequestBody(matchingJsonPath("$.param2", equalTo("1")))
+      )
+    }
+
+    "send a request with custom method" in {
+      val url = s"http://localhost:${wireMock.port()}"
+      val template = """{\"param1\": \"${string}\", \"param2\": ${number}}"""
+
+      //language=JSON
+      val config =
+        s"""
+           |{
+           |  "url": "$url",
+           |  "template": "$template",
+           |  "method": "PUT"
+           |}
+           |""".stripMargin
+
+      val data = Map("string" -> "string", "number" -> 1)
+
+      stubFor(put("/").willReturn(aResponse().withStatus(201)))
+
+      val subject = HttpJsonConsumer(ConfigFactory.parseString(config), pc)
+
+      val expectedJson = """{"param1": "string", "param2": 1}"""
+
+      subject.consumeSuccess(data).futureValue shouldBe Consumed(s"PUT $url with $expectedJson executed with success")
+
+      verify(
+        putRequestedFor(urlEqualTo("/"))
+          .withHeader("Content-Type", equalTo("application/json"))
+          .withRequestBody(matchingJsonPath("$.param1", equalTo("string")))
+          .withRequestBody(matchingJsonPath("$.param2", equalTo("1")))
+      )
+    }
+
+    "send a request to a dynamic URL" in {
+      val url = s"http://localhost:${wireMock.port()}"
+      val template = """{\"param1\": \"${string}\", \"param2\": ${number}}"""
+
+      //language=JSON
+      val config =
+        s"""
+           |{
+           |  "url": "$url/dynamic/$${param}",
+           |  "template": "$template",
+           |  "method": "PUT"
+           |}
+           |""".stripMargin
+
+      val data = Map("string" -> "string", "number" -> 1, "param" -> "extra")
+
+      stubFor(put("/dynamic/extra").willReturn(aResponse().withStatus(201)))
+
+      val subject = HttpJsonConsumer(ConfigFactory.parseString(config), pc)
+
+      val expectedJson = """{"param1": "string", "param2": 1}"""
+
+      subject.consumeSuccess(data).futureValue shouldBe Consumed(s"PUT $url/dynamic/extra with $expectedJson executed with success")
+
+      verify(
+        putRequestedFor(urlEqualTo("/dynamic/extra"))
+          .withHeader("Content-Type", equalTo("application/json"))
+          .withRequestBody(matchingJsonPath("$.param1", equalTo("string")))
+          .withRequestBody(matchingJsonPath("$.param2", equalTo("1")))
+      )
+
+    }
+  }
+
+}


### PR DESCRIPTION
Adds an HTTP consumer that sends JSON to a dynamic URL with a custom method (default POST).

This includes some refactoring that improve the HTTP extractor as well