### PR TITLE
Flatten extractor

### DIFF
--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/FlattenExtractor.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/FlattenExtractor.scala
@@ -1,0 +1,41 @@
+package it.ldsoftware.migra.engine.extractors
+
+import akka.stream.Materializer
+import com.typesafe.config.Config
+import it.ldsoftware.migra.engine.{Extracted, ExtractionResult, Extractor, ExtractorBuilder, ProcessContext}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FlattenExtractor(property: String, override val config: Config, override val initialValue: Extracted)(implicit
+    val ec: ExecutionContext,
+    mat: Materializer
+) extends Extractor {
+  override def doExtract(): Future[Seq[ExtractionResult]] = {
+    Future(initialValue)
+      .map(_.get(property))
+      .map {
+        case Some(value) => flatMapFromAny(value)
+        case None        => Seq(Left(s"No property $property found on $initialValue"))
+      }
+  }
+
+  private def flatMapFromAny(value: Any): Seq[ExtractionResult] = value match {
+    case seq if seq.isInstanceOf[Seq[Extracted]] => seq.asInstanceOf[Seq[Extracted]].map(Right(_))
+    case _ => Seq(Left(s"${value.getClass.getSimpleName} is not a sequence"))
+  }
+
+  override def toPipedExtractor(data: Extracted): Extractor =
+    new FlattenExtractor(property, config, data)
+
+  override def summary: String = s"FlattenExtractor with property $property and value $initialValue"
+}
+
+object FlattenExtractor extends ExtractorBuilder {
+  override def apply(config: Config, pc: ProcessContext): Extractor = {
+    val property = config.getString("property")
+    implicit val executionContext: ExecutionContext = pc.executionContext
+    implicit val materializer: Materializer = pc.materializer
+
+    new FlattenExtractor(property, config, Map())
+  }
+}

--- a/src/main/scala/it/ldsoftware/migra/extensions/ConfigExtensions.scala
+++ b/src/main/scala/it/ldsoftware/migra/extensions/ConfigExtensions.scala
@@ -20,5 +20,9 @@ object ConfigExtensions {
 
     def getOptDuration(path: String): Option[Duration] =
       if (config.hasPath(path)) Some(config.getDuration(path)) else None
+
+    def getOptConfig(path: String): Option[Config] =
+      if (config.hasPath(path)) Option(config.getConfig(path))
+      else None
   }
 }

--- a/src/test/scala/it/ldsoftware/migra/engine/extractors/ExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/extractors/ExtractorSpec.scala
@@ -9,7 +9,12 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures with IntegrationPatience with MockFactory {
+class ExtractorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with MockFactory {
 
   "an extractor" should {
     "emit new data when the configuration does not specify anything" in {
@@ -73,6 +78,94 @@ class ExtractorSpec extends AnyWordSpec with should.Matchers with ScalaFutures w
       val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
 
       val expected = Map("old" -> "value", "extracted" -> "template string")
+
+      extractor.extract().futureValue shouldBe Seq(Right(expected))
+    }
+
+    "prepend a value to the new extracted property name when conflict resolving is Prepend" in {
+      // language=JSON
+      val config =
+        """{
+          |  "extract":  [
+          |    {
+          |      "type":  "DummyExtractor",
+          |      "config": {
+          |        "parameter": "template string",
+          |        "mode": "merge",
+          |        "conflict": {
+          |           "action": "prepend",
+          |           "value": "new_"
+          |        }
+          |      }
+          |    }
+          |  ]
+          |}""".stripMargin
+
+      val data = Map("extracted" -> "value")
+
+      val c = ConfigFactory.parseString(config)
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
+      val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
+
+      val expected = Map("extracted" -> "value", "new_extracted" -> "template string")
+
+      extractor.extract().futureValue shouldBe Seq(Right(expected))
+    }
+
+    "append a value to the new extracted property name when conflict resolving is Append" in {
+      // language=JSON
+      val config =
+        """{
+          |  "extract":  [
+          |    {
+          |      "type":  "DummyExtractor",
+          |      "config": {
+          |        "parameter": "template string",
+          |        "mode": "merge",
+          |        "conflict": {
+          |           "action": "append",
+          |           "value": "_new"
+          |        }
+          |      }
+          |    }
+          |  ]
+          |}""".stripMargin
+
+      val data = Map("extracted" -> "value")
+
+      val c = ConfigFactory.parseString(config)
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
+      val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
+
+      val expected = Map("extracted" -> "value", "extracted_new" -> "template string")
+
+      extractor.extract().futureValue shouldBe Seq(Right(expected))
+    }
+
+    "substitute a value when conflict resolving is Substitute" in { // language=JSON
+      val config =
+        """{
+          |  "extract":  [
+          |    {
+          |      "type":  "DummyExtractor",
+          |      "config": {
+          |        "parameter": "template string",
+          |        "mode": "merge",
+          |        "conflict": {
+          |           "action": "substitute"
+          |        }
+          |      }
+          |    }
+          |  ]
+          |}""".stripMargin
+
+      val data = Map("extracted" -> "value")
+
+      val c = ConfigFactory.parseString(config)
+      val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
+      val extractor = ExtractorFactory.getExtractors(c, pc).head.toPipedExtractor(data)
+
+      val expected = Map("extracted" -> "template string")
 
       extractor.extract().futureValue shouldBe Seq(Right(expected))
     }

--- a/src/test/scala/it/ldsoftware/migra/engine/extractors/FlattenExtractorSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/extractors/FlattenExtractorSpec.scala
@@ -1,0 +1,65 @@
+package it.ldsoftware.migra.engine.extractors
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import it.ldsoftware.migra.configuration.AppConfig
+import it.ldsoftware.migra.engine.{FileResolver, ProcessContext}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.GivenWhenThen
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FlattenExtractorSpec extends AnyWordSpec
+  with GivenWhenThen
+  with Matchers
+  with MockFactory
+  with ScalaFutures
+  with IntegrationPatience {
+
+  private val system = ActorSystem("test-flatten-extractor")
+  private val pc = ProcessContext(system, mock[AppConfig], mock[FileResolver])
+
+  "the flatten extractor" should {
+    "return a collection sub-property of given data" in {
+
+      // language=JSON
+      val config =
+        """
+          |{
+          |  "property": "list"
+          |}
+          |""".stripMargin
+
+      val data = Map("list" -> Seq(Map("a" -> "a"), Map("b" -> "b"), Map("c" -> "c")))
+
+      val subject = FlattenExtractor(ConfigFactory.parseString(config), pc)
+        .toPipedExtractor(data)
+
+      val expected = Seq(Right(Map("a" -> "a")), Right(Map("b" -> "b")), Right(Map("c" -> "c")))
+
+      subject.extract().futureValue shouldBe expected
+    }
+
+    "fail if the data does not contain given sub-property" in {
+      // language=JSON
+      val config =
+        """
+          |{
+          |  "property": "wrong"
+          |}
+          |""".stripMargin
+
+      val data = Map("key" -> "value")
+
+      val subject = FlattenExtractor(ConfigFactory.parseString(config), pc)
+        .toPipedExtractor(data)
+
+      val expected = Seq(Left("No property wrong found on Map(key -> value)"))
+
+      subject.extract().futureValue shouldBe expected
+
+    }
+  }
+
+}


### PR DESCRIPTION
Adding a flatMap - like extractor that will take a collection property from the extracted data and unwrap its objects into the process stream. For example, if we have a previous step that returns a list of companies, containing a list of cities where they are present, the next step of the process will have as input all cities of all companies.

This PR also introduces the conflict resolution, for example if we decided to merge companies and cities together after the flatten extraction is done, we could have conflicting fields (such as an ID field with the same name). If such things occur, we can specify how to deal with the conflict, we can:
- ignore it (default behavior) and the new value will prevail over the old one
- prepend a string to the newly extracted existing keys, e.g. in the case before of cities and companies we can prepend `city_`, so the next step will have `city_id` to represent cities and `id` will remain unchanged for companies
- append a string, as in the case before, but the string value will be at the end of the key (e.g. `id_city`)