### PR TITLE
Optimise output logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val integration = (project in file("integration"))
+  .settings(CompilerSettings.settings)
   .dependsOn(root)
   .settings(
     publish / skip := true,

--- a/integration/src/test/scala/it/ldsoftware/migra/DatabaseUtils.scala
+++ b/integration/src/test/scala/it/ldsoftware/migra/DatabaseUtils.scala
@@ -2,7 +2,7 @@ package it.ldsoftware.migra
 
 import com.typesafe.config.ConfigFactory
 import slick.jdbc.JdbcBackend.Database
-import slick.jdbc._
+import slick.jdbc.*
 
 object DatabaseUtils {
 

--- a/integration/src/test/scala/it/ldsoftware/migra/MigraStandaloneSpec.scala
+++ b/integration/src/test/scala/it/ldsoftware/migra/MigraStandaloneSpec.scala
@@ -63,7 +63,7 @@ class MigraStandaloneSpec
         val generated = new File("src/test/resources/")
           .listFiles()
           .map(_.getAbsolutePath)
-          .filter(_.contains("executed"))
+          .filter(_.contains(".log"))
         generated should have size 1
 
         val log = Source.fromFile(generated(0)).use(_.getLines().toList)
@@ -78,7 +78,7 @@ class MigraStandaloneSpec
 
       new File("src/test/resources/")
         .listFiles()
-        .filter(_.getAbsolutePath.contains("executed"))
+        .filter(_.getAbsolutePath.contains(".log"))
         .foreach(_.delete())
     }
   }

--- a/integration/src/test/scala/it/ldsoftware/migra/MigraStandaloneSpec.scala
+++ b/integration/src/test/scala/it/ldsoftware/migra/MigraStandaloneSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.File
 import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.io.Source
 
 //noinspection SqlDialectInspection,SqlNoDataSourceInspection
@@ -22,7 +22,7 @@ class MigraStandaloneSpec
     with Eventually
     with IntegrationPatience {
 
-  import slick.jdbc.H2Profile.api._
+  import slick.jdbc.H2Profile.api.*
 
   private val jdbcUrl = "jdbc:h2:mem:integration;DB_CLOSE_ON_EXIT=FALSE"
   val db = DatabaseUtils.getDatabase(jdbcUrl, "org.h2.Driver")

--- a/integration/src/test/scala/it/ldsoftware/migra/engine/consumers/DatabaseConsumerIntSpec.scala
+++ b/integration/src/test/scala/it/ldsoftware/migra/engine/consumers/DatabaseConsumerIntSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 //noinspection SqlDialectInspection,SqlNoDataSourceInspection
 class DatabaseConsumerIntSpec
@@ -27,7 +27,7 @@ class DatabaseConsumerIntSpec
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(15, Millis)))
 
-  import slick.jdbc.H2Profile.api._
+  import slick.jdbc.H2Profile.api.*
 
   private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"

--- a/integration/src/test/scala/it/ldsoftware/migra/engine/extractors/DatabaseExtractorIntSpec.scala
+++ b/integration/src/test/scala/it/ldsoftware/migra/engine/extractors/DatabaseExtractorIntSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 //noinspection SqlDialectInspection,SqlNoDataSourceInspection
 class DatabaseExtractorIntSpec
@@ -22,7 +22,7 @@ class DatabaseExtractorIntSpec
     with IntegrationPatience
     with IdiomaticMockito {
 
-  import slick.jdbc.H2Profile.api._
+  import slick.jdbc.H2Profile.api.*
 
   private val pc = ProcessContext(ActorSystem("test"), mock[AppConfig], mock[FileResolver])
   private val jdbcUrl = s"jdbc:h2:mem:${RandomStringUtils.randomAlphanumeric(10)};DB_CLOSE_DELAY=-1"

--- a/src/main/scala/it/ldsoftware/migra/engine/ProcessStats.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/ProcessStats.scala
@@ -1,0 +1,6 @@
+package it.ldsoftware.migra.engine
+
+case class ProcessStats(consumed: Int, notConsumed: Int) {
+  def withSuccess: ProcessStats = copy(consumed + 1, notConsumed)
+  def withFailure: ProcessStats = copy(consumed, notConsumed + 1)
+}

--- a/src/main/scala/it/ldsoftware/migra/engine/ProcessStream.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/ProcessStream.scala
@@ -34,7 +34,7 @@ class ProcessStream(extractors: List[Extractor], consumers: List[Consumer], parL
 
   def executionGraph(sink: Sink[ConsumerResult, Future[ProcessStats]]): Graph[ClosedShape, Future[ProcessStats]] =
     GraphDSL.createGraph(sink) { implicit builder => sink =>
-      import GraphDSL.Implicits._
+      import GraphDSL.Implicits.*
 
       val piped = pipe.foldLeft(input ~> identity) { case (acc, next) =>
         acc ~> next

--- a/src/main/scala/it/ldsoftware/migra/engine/ProcessStream.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/ProcessStream.scala
@@ -13,9 +13,9 @@ class ProcessStream(extractors: List[Extractor], consumers: List[Consumer], parL
       .future(extractors.head.extract())
       .flatMapConcat(i => Source(i))
 
-  lazy val identity: Flow[ExtractionResult, ExtractionResult, NotUsed] = Flow[ExtractionResult]
+  private lazy val identity: Flow[ExtractionResult, ExtractionResult, NotUsed] = Flow[ExtractionResult]
 
-  lazy val pipe: List[Flow[ExtractionResult, ExtractionResult, NotUsed]] =
+  private lazy val pipe: List[Flow[ExtractionResult, ExtractionResult, NotUsed]] =
     extractors.tail.map { e =>
       e.throttling
         .map(d => Flow[ExtractionResult].throttle(1, d))
@@ -32,7 +32,7 @@ class ProcessStream(extractors: List[Extractor], consumers: List[Consumer], parL
         .mapAsync(parLevel)(rd => c.consume(rd))
     }
 
-  def executionGraph(sink: Sink[ConsumerResult, Future[String]]): Graph[ClosedShape, Future[String]] =
+  def executionGraph(sink: Sink[ConsumerResult, Future[ProcessStats]]): Graph[ClosedShape, Future[ProcessStats]] =
     GraphDSL.createGraph(sink) { implicit builder => sink =>
       import GraphDSL.Implicits._
 

--- a/src/main/scala/it/ldsoftware/migra/engine/consumers/ConsumerFactory.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/consumers/ConsumerFactory.scala
@@ -2,7 +2,7 @@ package it.ldsoftware.migra.engine.consumers
 
 import com.typesafe.config.Config
 import it.ldsoftware.migra.engine.{getBuilder, Consumer, ConsumerBuilder, ProcessContext}
-import it.ldsoftware.migra.extensions.ConfigExtensions._
+import it.ldsoftware.migra.extensions.ConfigExtensions.*
 
 object ConsumerFactory {
 

--- a/src/main/scala/it/ldsoftware/migra/engine/consumers/DatabaseConsumer.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/consumers/DatabaseConsumer.scala
@@ -1,7 +1,7 @@
 package it.ldsoftware.migra.engine.consumers
 
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 import it.ldsoftware.migra.extensions.DatabaseExtensions
 import it.ldsoftware.migra.extensions.Interpolator.ExtendedConnection
 import it.ldsoftware.migra.extensions.UsableExtensions.{LetOperations, UsableCloseable}

--- a/src/main/scala/it/ldsoftware/migra/engine/consumers/PrinterConsumer.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/consumers/PrinterConsumer.scala
@@ -2,8 +2,8 @@ package it.ldsoftware.migra.engine.consumers
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import it.ldsoftware.migra.engine._
-import it.ldsoftware.migra.extensions.Interpolator._
+import it.ldsoftware.migra.engine.*
+import it.ldsoftware.migra.extensions.Interpolator.*
 import it.ldsoftware.migra.extensions.UsableExtensions.LetOperations
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/DatabaseExtractor.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/DatabaseExtractor.scala
@@ -1,11 +1,11 @@
 package it.ldsoftware.migra.engine.extractors
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 import it.ldsoftware.migra.engine.extractors.DatabaseExtractor.resultSetToList
 import it.ldsoftware.migra.extensions.DatabaseExtensions
-import it.ldsoftware.migra.extensions.Interpolator._
+import it.ldsoftware.migra.extensions.Interpolator.*
 import it.ldsoftware.migra.extensions.UsableExtensions.{LetOperations, UsableCloseable}
-import slick.jdbc._
+import slick.jdbc.*
 
 import java.sql.ResultSet
 import javax.sql.DataSource

--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/ExtractorFactory.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/ExtractorFactory.scala
@@ -2,7 +2,7 @@ package it.ldsoftware.migra.engine.extractors
 
 import com.typesafe.config.Config
 import it.ldsoftware.migra.engine.{getBuilder, Extractor, ExtractorBuilder, ProcessContext}
-import it.ldsoftware.migra.extensions.ConfigExtensions._
+import it.ldsoftware.migra.extensions.ConfigExtensions.*
 
 object ExtractorFactory {
 

--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/HttpExtractor.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/HttpExtractor.scala
@@ -1,14 +1,14 @@
 package it.ldsoftware.migra.engine.extractors
 
 import akka.http.scaladsl.HttpExt
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.*
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 import it.ldsoftware.migra.extensions.ConfigExtensions.ConfigOperations
 import it.ldsoftware.migra.extensions.Interpolator.StringInterpolator
-import it.ldsoftware.migra.extensions.JacksonExtension._
+import it.ldsoftware.migra.extensions.JacksonExtension.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/it/ldsoftware/migra/engine/extractors/ScalaEvalExtractor.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/extractors/ScalaEvalExtractor.scala
@@ -1,7 +1,7 @@
 package it.ldsoftware.migra.engine.extractors
 
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 import it.ldsoftware.migra.extensions.ScriptEngineExtensions.ScriptEnginePool
 
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/it/ldsoftware/migra/engine/providers/OAuth2TokenProvider.scala
+++ b/src/main/scala/it/ldsoftware/migra/engine/providers/OAuth2TokenProvider.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
-import io.circe.generic.auto._
+import io.circe.generic.auto.*
 import it.ldsoftware.migra.engine.providers.OAuth2TokenProvider.{Credentials, OAuth2Authentication, TimedToken}
 import it.ldsoftware.migra.engine.{ProcessContext, TokenProvider, TokenProviderBuilder}
 

--- a/src/main/scala/it/ldsoftware/migra/extensions/DatabaseExtensions.scala
+++ b/src/main/scala/it/ldsoftware/migra/extensions/DatabaseExtensions.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.migra.extensions
 import com.typesafe.config.Config
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import it.ldsoftware.migra.extensions.UsableExtensions.{LetOperations, MutateOperations}
-import ConfigExtensions._
+import ConfigExtensions.*
 
 import javax.sql.DataSource
 import scala.collection.mutable

--- a/src/test/scala/it/ldsoftware/migra/engine/consumers/DummyConsumer.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/consumers/DummyConsumer.scala
@@ -1,7 +1,7 @@
 package it.ldsoftware.migra.engine.consumers
 
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/test/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumerSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/consumers/HttpJsonConsumerSpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.migra.engine.consumers
 import akka.actor.ActorSystem
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.typesafe.config.ConfigFactory
 import it.ldsoftware.migra.configuration.AppConfig

--- a/src/test/scala/it/ldsoftware/migra/engine/extractors/DummyExtractor.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/extractors/DummyExtractor.scala
@@ -1,7 +1,7 @@
 package it.ldsoftware.migra.engine.extractors
 
 import com.typesafe.config.Config
-import it.ldsoftware.migra.engine._
+import it.ldsoftware.migra.engine.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/test/scala/it/ldsoftware/migra/engine/providers/OAuth2TokenProviderSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/engine/providers/OAuth2TokenProviderSpec.scala
@@ -3,7 +3,7 @@ package it.ldsoftware.migra.engine.providers
 import akka.actor.ActorSystem
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory

--- a/src/test/scala/it/ldsoftware/migra/extensions/InterpolatorSpec.scala
+++ b/src/test/scala/it/ldsoftware/migra/extensions/InterpolatorSpec.scala
@@ -1,6 +1,6 @@
 package it.ldsoftware.migra.extensions
 
-import it.ldsoftware.migra.extensions.Interpolator._
+import it.ldsoftware.migra.extensions.Interpolator.*
 import org.mockito.IdiomaticMockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec


### PR DESCRIPTION
Creating the output logs as the application progresses rather than collecting all strings in memory and potentially filling the buffer too much.